### PR TITLE
Add 4.12 and 4.13 to ignored OCP versions

### DIFF
--- a/.github/scripts/gpu_operator_versions/settings.json
+++ b/.github/scripts/gpu_operator_versions/settings.json
@@ -14,6 +14,6 @@
       "status": "active"
     }
   },
-  "ignored_versions_regex": "^4.[0-9]$|^4.1[0-1]$"
+  "ignored_versions_regex": "^4.[0-9]$|^4.1[0-3]$"
 }
 


### PR DESCRIPTION
OCP 4.12 and 4.13 no longer receive new versions of the GPU operator. The latest version 25.3 available on these OCP has became unsupported with the release of 26.3.

Keep the "openshif_support" section as an example, although it does not make sense now that we do not test 4.12 & 4.13 at all.